### PR TITLE
Solve StopAR issue with video

### DIFF
--- a/editor/js/components/arcontroller.component.js
+++ b/editor/js/components/arcontroller.component.js
@@ -304,11 +304,20 @@ ArControllerComponent.prototype.resize = function(cw, ch, vw, vh) {
 ArControllerComponent.prototype.stopAR = function(){
     console.log("Stop AR");
     this.running = false;
-    if(this.arController)
-        this.arController.dispose();
     if(this._video !== undefined){
-        this._video.srcObject.getTracks()[0].stop();
-        this._video.remove();
+      console.log(this._video);
+      var videoElem = this._video;
+      var stream = videoElem.srcObject;
+      var tracks = stream.getVideoTracks();
+      tracks.forEach(function(track) {
+        track.stop();
+      });
+
+      videoElem.srcObject = null;
+      videoElem.src = null;
+      videoElem.remove();
+      if(this.arController)
+          this.arController.dispose();
     }
 
     if(this.arCamera)


### PR DESCRIPTION
This PR solve the  issue https://github.com/augmentmy-world/arStudio/issues/5.
The video was already deleted by ` this.arController.dispose();` see the code: https://github.com/augmentmy-world/arStudio/blob/08583457e9969023168b86d0eefd24f37a151659/editor/js/components/arcontroller.component.js#L304-L312
For this reason **getTracks()** find the video src as null and fails. My code solution move the **dispose()** after the **getTracks()** call and perform a iteration to stop eventually other videos stream. 
My solution:
```js
ArControllerComponent.prototype.stopAR = function(){
    console.log("Stop AR");
    this.running = false;
    if(this._video !== undefined){
      console.log(this._video);
      var videoElem = this._video;
      var stream = videoElem.srcObject;
      var tracks = stream.getVideoTracks();
      tracks.forEach(function(track) {
        track.stop();
      });

      videoElem.srcObject = null;
      videoElem.src = null;
      videoElem.remove();
      if(this.arController)
          this.arController.dispose();
    }

```
I used **getVideoTracks()** instead of **getTracks()** ,  i am not sure which one is better ro use.